### PR TITLE
IconButtonの誤った属性名を修正

### DIFF
--- a/components/uploadButton.js
+++ b/components/uploadButton.js
@@ -24,7 +24,7 @@ const UploadButton = props => (
     <label htmlFor="file-input">
       <IconButton
         color="primary"
-        size="large"
+        size="medium"
         disabled={props.disabled}
         aria-label="upload audio"
         component="span"


### PR DESCRIPTION
close #13

IconButtonのsize属性に不正な値を指定していたので`medium`に修正した。